### PR TITLE
Update build.bat for resolved RestSharp bug

### DIFF
--- a/client/build.bat
+++ b/client/build.bat
@@ -12,6 +12,6 @@ if not exist ".\bin" mkdir bin
 
 copy packages\Newtonsoft.Json.10.0.3\lib\net45\Newtonsoft.Json.dll bin\Newtonsoft.Json.dll
 copy packages\JsonSubTypes.1.2.0\lib\net45\JsonSubTypes.dll bin\JsonSubTypes.dll
-copy packages\RestSharp.105.1.0\lib\net45\RestSharp.dll bin\RestSharp.dll
+copy packages\RestSharp.106.6.10\lib\net452\RestSharp.dll bin\RestSharp.dll
 %CSCPATH%\csc  /reference:bin\Newtonsoft.Json.dll;bin\JsonSubTypes.dll;bin\RestSharp.dll;System.ComponentModel.DataAnnotations.dll  /target:library /out:bin\Cloudmersive.APIClient.NET.VirusScan.dll /recurse:src\Cloudmersive.APIClient.NET.VirusScan\*.cs /doc:bin\Cloudmersive.APIClient.NET.VirusScan.xml
 


### PR DESCRIPTION
built.bat fails since RestSharp call in apiclient.cs has been updated with a new signature which is not backwards compatible.

