### PR TITLE
fix missing xml param warning

### DIFF
--- a/client/src/Cloudmersive.APIClient.NET.VirusScan/Client/ApiClient.cs
+++ b/client/src/Cloudmersive.APIClient.NET.VirusScan/Client/ApiClient.cs
@@ -497,6 +497,7 @@ namespace Cloudmersive.APIClient.NET.VirusScan.Client
         /// Convert params to key/value pairs. 
         /// Use collectionFormat to properly format lists and collections.
         /// </summary>
+        /// <param name="collectionFormat">Format to use</param>
         /// <param name="name">Key name.</param>
         /// <param name="value">Value object.</param>
         /// <returns>A list of KeyValuePairs</returns>


### PR DESCRIPTION
this just adds an xml comment for one parameter so to remove the build warning its absence was causing.